### PR TITLE
Fixs

### DIFF
--- a/Channl32/PacketHandler.cpp
+++ b/Channl32/PacketHandler.cpp
@@ -459,7 +459,7 @@ void PacketHandler::GenerateResponse(int ResponsePacketType)
 		Join_Channel_PlayerData_Response.bunk[6] = 0;
 		Join_Channel_PlayerData_Response.Rank = 101;
 		Join_Channel_PlayerData_Response.unk43 = 1; //1
-		Join_Channel_PlayerData_Response.maxroom = MaxRoom; //0x108
+		Join_Channel_PlayerData_Response.maxroom = MAXROOM; //0x108
 		memset((void*)&Join_Channel_PlayerData_Response.munk1, -1, 4 * 8); //-1
 		Join_Channel_PlayerData_Response.unk45 = 7; //7
 		Join_Channel_PlayerData_Response.unk46 = 0x120101; //0x120101
@@ -917,7 +917,7 @@ void PacketHandler::GenerateResponse(int ResponsePacketType)
 	break;
 	case ROOM_EXIT_RESPONSE:
 		GetExitRoomResponse();
-		for (int i = 0; i < MaxRoom; i++)
+		for (int i = 0; i < MAXROOM; i++)
 		{
 			if (RoomList.Rooms[i].n != -1) {
 				HandleList.ProdcastRoomUpdate(RoomList.Rooms[i].n);

--- a/Channl32/SP_Functions.h
+++ b/Channl32/SP_Functions.h
@@ -161,7 +161,7 @@ void PacketHandler::GetInRoomUpgradeResponse(CardUpgradeResponse *CUR) {
 void PacketHandler::GetRoomListResponse() {
 	for (int i = 0; i < 22; i++)Room_List_Response.bunk[i] = true;
 	int x = 0;
-	for (int i = 0; i < MaxRoom; i++) {
+	for (int i = 0; i < MAXROOM; i++) {
 		if (x == 0) {
 			memset(&Room_List_Response, 0, sizeof(Room_List_Response));
 			Room_List_Response.size = sizeof(Room_List_Response);
@@ -182,7 +182,7 @@ void PacketHandler::GetRoomListResponse() {
 			}
 			x++;
 		}
-		if (x == 22 || i == (MaxRoom - 1)) {
+		if (x == 22 || i == (MAXROOM - 1)) {
 			while (x < 22)
 			{
 				Room_List_Response.roomnumber[x] = -1;

--- a/Channl32/UserList.h
+++ b/Channl32/UserList.h
@@ -25,6 +25,8 @@
 #define MISSION_IMPOSSIBLE_300 47
 #define COMMUNITY_MODE 1
 
+#define MaxRoom 300
+
 LobbyList::LobbyList()
 {
 	count = 0;
@@ -248,6 +250,28 @@ public:
 					for (int i = 0; i < 13; i++)LRR->zeros[i] = 0;
 					LRR->unk9 = 0x100;
 			}
+	}
+	void GetRoomList(RoomListResponse* RLR) {
+		int x = 0;
+		for (int i = 0; i < MaxRoom; i++)
+			if (Rooms[i].n != -1) {
+				RLR->roomnumber[x] = Rooms[i].n;
+				strcpy(RLR->title[x], Rooms[i].title);
+				RLR->mode[x] = Rooms[i].mode;
+				RLR->map[x] = Rooms[i].map;
+				RLR->maxplayers[x] = Rooms[i].maxp;
+				RLR->unks2[x] = 1;
+				RLR->unks4[x] = -1;
+				for (int j = 0; j < Rooms[i].maxp - 1; j++) {
+					RLR->players[x][j] = Rooms[i].Player[j] ? Rooms[i].Player[j]->Info.usr_char : 0;
+				}
+				x++;
+			}
+		while (x < MaxRoom)
+		{
+			RLR->roomnumber[x] = -1;
+			x++;
+		}
 	}
 	void GetRoomPlayerList(int n, RoomPlayerListResponse *RPLR) {
 		for (int i = 0; i < MaxRoom; i++)


### PR DESCRIPTION
Room
- check current number player in room before get in
- check the game is started or not

create room
- only allow scrolls in quest
- disable angel sheild
- auto incremental  the room number if the room is existed
- check the server room list is full or not

room update
- display the current number of player
- display angel shield

roomlist problem
- i dont know i do it right or not i use memset to clear the Player[]
array
- also add sth to the destructor of the packethandler